### PR TITLE
[GSPQ-219] Added --no-inline-config to eslint sonar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Basically this plugin launches EsLint and collects its results into SonarQube. I
 
 ## Changelog
 
+0.3.1 - Added --no-inline-config to the eslint arguments, ensuring that even the eslint-disable comments will be
+registered
+
 0.3.0 - Upgrade to the latest Sonar API and dependencies and fix an issue (#2) when ESLint is meeting parsing errors or simply ignoring files.
  * SonarQube API 6.7
  

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Basically this plugin launches EsLint and collects its results into SonarQube. I
 
 ## Changelog
 
-0.3.1 - Added --no-inline-config to the eslint arguments, ensuring that even the eslint-disable comments will be
+0.3.2 - Added --no-inline-config to the eslint arguments, ensuring that even the eslint-disable comments will be
 registered
+
+0.3.1 - Added configure-eslint-natura-rules
 
 0.3.0 - Upgrade to the latest Sonar API and dependencies and fix an issue (#2) when ESLint is meeting parsing errors or simply ignoring files.
  * SonarQube API 6.7

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.github.sleroy.io</groupId>
 	<artifactId>sonar-eslint-plugin</artifactId>
 	<packaging>sonar-plugin</packaging>
-	<version>0.3.1</version>
+	<version>0.3.2</version>
 
 	<name>ESLint</name>
 	<description>Analyse ESLint projects</description>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.17.0</version>
+			<version>2.23.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/io/github/sleroy/sonar/EsLintExecutorImpl.java
+++ b/src/main/java/io/github/sleroy/sonar/EsLintExecutorImpl.java
@@ -60,6 +60,9 @@ public class EsLintExecutorImpl implements EsLintExecutor {
                 .addArgument("-f")
                 .addArgument("json");
 
+        //Add argument to eslint ignore the eslint-disable comments
+        command.addArgument("--no-inline-config");
+
         String rulesDir = config.getRulesDir();
         if (rulesDir != null && !rulesDir.isEmpty()) {
             command

--- a/src/test/java/io/github/sleroy/sonar/EsLintExecutorImplTest.java
+++ b/src/test/java/io/github/sleroy/sonar/EsLintExecutorImplTest.java
@@ -148,7 +148,7 @@ public class EsLintExecutorImplTest {
 	final long theTimeout = capturedTimeouts.get(0);
 
 	assertEquals(
-		"node path/to/eslint -f json --rules-dir path/to/rules --output-file path/to/temp --config path/to/config path/to/file path/to/another",
+		"node path/to/eslint -f json --no-inline-config --rules-dir path/to/rules --output-file path/to/temp --config path/to/config path/to/file path/to/another",
 		theCommand.toCommandLine());
 	// Expect one timeout period per file processed
 	assertEquals(2 * 40000, theTimeout);


### PR DESCRIPTION
Adding this argument the eslint will cover even with the eslint-disable comments inside the code