### PR TITLE
[GSPQ-220] solved the problem with rules with line 0 issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ We don't have plans to add those changes in the original plugin, but if we creat
 
 ## Changelog
 
+0.3.4 - Modified the ESLint plugin to deal with issues that registers line as 0
+
+0.3.3 - Added ESLint rules to disable-inline plugin
+
 0.3.2 - Added --no-inline-config to the eslint arguments, ensuring that even the eslint-disable comments will be
 registered
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.github.sleroy.io</groupId>
 	<artifactId>sonar-eslint-plugin</artifactId>
 	<packaging>sonar-plugin</packaging>
-	<version>0.3.3</version>
+	<version>0.3.4</version>
 
 	<name>ESLint</name>
 	<description>Analyse ESLint projects</description>

--- a/src/main/java/io/github/sleroy/sonar/model/EsLintIssue.java
+++ b/src/main/java/io/github/sleroy/sonar/model/EsLintIssue.java
@@ -59,10 +59,16 @@ public class EsLintIssue {
     }
 
     public int getLine() {
+        if (line == 0) {
+            return 1;
+        }
         return line;
     }
 
     public void setLine(int line) {
+        if (line == 0) {
+            line = 1;
+        }
         this.line = line;
     }
 


### PR DESCRIPTION
The ESLint can sometimes register Line 0 at issue construction, whereas the slevomat ESLint plugin couldn't handle that.

I put just a basic defensive code into EsLintIssue class that will work fine with any rules that holds line 0 at issue instance;